### PR TITLE
Add restarability to the training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ output
 __pycache__
 .mypy_cache/
 .idea/
+data/

--- a/README.md
+++ b/README.md
@@ -58,10 +58,17 @@ The default values for most of these parameters are the ones that were used to o
 
 - `hidden_drop`: drop out rate for hidden layer of all models.
 
+- `no_test_by_arity`: when set, test results will not be saved by arity, but as a whole. This generally makes testing faster. 
+
 - `test`: when set, this will test a trained model on the test dataset. If this option is present, then you must specify the path to a trained model using `-pretrained` argument.
 
-- `pretrained`: The path to a pretrained model file. If this path exists, then the code will load a pretrained model before starting the train or test process.
-The filename is expected to have the form `model_*.chkpnt`. The directory containing this file is expected to also contain the optimizer as `opt_*.chkpnt`, since it will also be loaded. 
+- `pretrained`: the path to a pretrained model file. If this path exists, then the code will load a pretrained model before starting the train or test process.
+The filename is expected to have the form `model_*.chkpnt`. The directory containing this file is expected to also contain the optimizer as `opt_*.chkpnt`, if training is to resume. 
+
+- `output_dir`: the path to the output directory where the results and models will be saved. If left empty, then a directory will be automatically created.
+
+- `restartable`: when set, the training job will be restartable: it will load the model from the last saved checkpoint in `output_dir`, as well as the `best_model`, and resume training from that point on.
+If this option is set, you must also specify `output_dir`.
 
 
 ## Training `HypE` and `HSimplE` 

--- a/dataset.py
+++ b/dataset.py
@@ -14,6 +14,7 @@ class Dataset:
         self.ent2id = {"":0}
         self.rel2id = {"":0}
         self.data = {}
+        print("Loading the dataset {} ....".format(ds_name))
         self.data["train"] = self.read(os.path.join(self.dir, "train.txt"))
         # Shuffle the train set
         np.random.shuffle(self.data['train'])

--- a/main.py
+++ b/main.py
@@ -14,31 +14,34 @@ DEFAULT_SAVE_DIR = 'output'
 DEFAULT_MAX_ARITY = 6
 
 class Experiment:
-
-    def __init__(self, model_name, dataset, num_iterations, batch_size, learning_rate, emb_dim, max_arity, hidden_drop,
-                 input_drop, neg_ratio, in_channels, out_channels, filt_h, filt_w, stride, pretrained, no_test_by_arity):
-        self.model_name = model_name
-        self.learning_rate = learning_rate
-        self.emb_dim = emb_dim
-        self.batch_size = batch_size
-        self.neg_ratio = neg_ratio
-        self.max_arity = max_arity
-        self.dataset = dataset
-        self.pretrained = pretrained
+    def __init__(self, args):
+        self.model_name = args.model
+        self.learning_rate = args.lr
+        self.emb_dim = args.emb_dim
+        self.batch_size = args.batch_size
+        self.neg_ratio = args.nr
+        self.max_arity = DEFAULT_MAX_ARITY
+        self.dataset = args.dataset
+        self.pretrained = args.pretrained
+        self.test = args.test
+        self.output_dir = args.output_dir
+        self.restartable = args.test
         self.device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-        self.kwargs = {"in_channels":in_channels,"out_channels": out_channels, "filt_h": filt_h, "filt_w": filt_w,
-                       "hidden_drop": hidden_drop, "stride": stride, "input_drop":input_drop}
-        self.hyperpars = {"model": model_name,"lr":learning_rate,"emb_dim":emb_dim,"out_channels":out_channels,
-                          "filt_w":filt_w,"nr":neg_ratio,"stride":stride, "hidden_drop":hidden_drop, "input_drop":input_drop}
+        self.kwargs = {"in_channels":args.in_channels,"out_channels":args.out_channels, "filt_h":args.filt_h, "filt_w":args.filt_w,
+                       "hidden_drop":args.hidden_drop, "stride":args.stride, "input_drop":args.input_drop}
+        self.hyperpars = {"model":args.model,"lr":args.lr,"emb_dim":args.emb_dim,"out_channels":args.out_channels,
+                          "filt_w":filt_w,"nr":args.nr,"stride":args.stride, "hidden_drop":args.hidden_drop, "input_drop":args.input_drop}
 
 
         self.num_iterations = num_iterations
         self.stride = stride
-        # Create an output dir unless a pretrained directory is given
-        self.output_dir = self.create_output_dir(pretrained)
+        # Create an output dir unless one is given
+        self.output_dir = self.create_output_dir(output_dir)
         self.measure = None
         self.measure_by_arity = None
         self.test_by_arity = not no_test_by_arity
+        self.best_model = None
+        self.best_mrr = 0
         # Load the specified model and initialize based on given checkpoint (if any)
         self.load_model()
 
@@ -60,36 +63,100 @@ class Experiment:
         seq = self.decompose_predictions(targets, predictions, max_length)
         return torch.stack(seq)
 
+    def get_model_from_name(self, model_name):
+        """
+        Instantiate a model object given the model name
+        """
+        model = None
+        if(model_name == "MDistMult"):
+            model = MDistMult(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
+        elif(model_name == "MCP"):
+            model = MCP(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
+        elif(model_name == "HSimplE"):
+            model = HSimplE(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
+        elif(model_name == "HypE"):
+            model = HypE(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
+        elif(model_name == "MTransH"):
+            model = MTransH(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
+        else:
+            raise Exception("!!!! No mode called {} found !!!!".format(self.model_name))
+        return model
+
+
+    def load_last_saved_model(self, output_dir):
+        """
+        Find the last saved model in the output_dir and load it.
+        Load also the best_model and best_mrr
+        If no model found in the output_dir or if the dir does not exists
+        initialize the model randomly.
+        Sets self.model, self.best_model
+        """
+        model_found = False
+        # If the output_dir contains a model, then it will be loaded
+        # Pick the latest saved model
+        try:
+            # List the checkpoint files in the dir
+            models_list = sorted(glob.glob(os.path.join(self.outut_dir, 'model_*.chkpnt')),
+                key=lambda f: int(re.match(r'model_(\d+)itr.chkpnt', f).groups(0)[0]))
+        except:
+            print("*** NO SAVED MODEL FOUND in {}. LOADING FROM SCRATCH. ****".format(self.output_dir))
+            # Initilize the model
+            self.model.init()
+        else: # if no exceptions, then run the following code
+            # If there are saved models
+            if len(models_list) > 0:
+                # Pick the most recent model
+                self.pretrained = os.path.join(self.output_dir, models_list[-1])
+                # Construct the name of the optimizer file based on the pretrained model path
+                opt_path = os.path.join(os.path.dirname(self.pretrained), os.path.basename(self.pretrained).replace('model','opt'))
+                if os.path.exists(opt_path):
+                    print("Loading the model {}".format(self.pretrained))
+                    self.model.load_state_dict(torch.load(self.pretrained))
+                    self.opt.load_state_dict(torch.load(opt_path))
+                    model_found = True
+
+                    try:
+                        # Load the best model
+                        best_model_path = os.path.join(self.output_dir, "best_model.chkpnt")
+                        self.best_model = get_model_from_name(self.model_name)
+                        self.best_model.load_state_dict(torch.load(best_model_path))
+                        self.best_mrr = self.best_model.best_mrr.data
+                    except:
+                        print("*** NO BEST MODEL FOUND in {}. ****".format(self.output_dir))
+                        # Set the best model to None
+                        self.best_model = None
+                        self.best_mrr = 0
+
+        if not model_found:
+            print("*** NO MODEL/OPTIMIZER FOUND in {}. LOADING FROM SCRATCH. ****".format(self.output_dir))
+            # Initilize the model
+            self.model.init()
+
 
     def load_model(self):
         """ If a pretrained model is provided, then it will be loaded. """
+        """ If the output_dir contains a (half-)trained model, then it will be loaded """
+        """ Priority is given to pretrained model. """
+
         print("Initializing the model ...")
-        if(self.model_name == "MDistMult"):
-            self.model = MDistMult(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
-        elif(self.model_name == "MCP"):
-            self.model = MCP(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
-        elif(self.model_name == "HSimplE"):
-            self.model = HSimplE(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
-        elif(self.model_name == "HypE"):
-            self.model = HypE(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
-        elif(self.model_name == "MTransH"):
-            self.model = MTransH(self.dataset, self.emb_dim, **self.kwargs).to(self.device)
-        else:
-            raise Exception("!!!! No mode called {} found !!!!".format(self.model_name))
+        self.model = get_model_from_name(self.model_name)
 
         # Load the pretrained model
         self.opt = torch.optim.Adagrad(self.model.parameters(), lr=self.learning_rate)
-        if self.pretrained is not None:
-            print("Loading the pretrained model at {}".format(self.pretrained))
+
+        if self.test and self.pretrained is not None:
+            print("Loading the pretrained model at {} for testing".format(self.pretrained))
             self.model.load_state_dict(torch.load(self.pretrained))
             # Construct the name of the optimizer file based on the pretrained model path
             opt_path = os.path.join(os.path.dirname(self.pretrained), os.path.basename(self.pretrained).replace('model','opt'))
             # If an optimizer exists (needed for training, but not testing), then load it.
-            if os.path.exists(opt_path):
-                self.opt.load_state_dict(torch.load(opt_path))
-            else:
-                print("*** NO OPTIMIZER FOUND. SKIPPING. ****")
-
+            #if os.path.exists(opt_path):
+            #    self.opt.load_state_dict(torch.load(opt_path))
+            #else:
+            #    print("*** NO OPTIMIZER FOUND. SKIPPING. ****")
+        elif self.restartable and os.isdir(self.output_dir):
+            # If the output_dir contains a model, then it will be loaded
+            load_last_saved_model(self.output_dir):
         else:
             # Initilize the model
             self.model.init()
@@ -115,11 +182,9 @@ class Experiment:
         print("Training the {} model...".format(self.model_name))
         print("Number of training data points: {}".format(len(self.dataset.data["train"])))
 
-        best_model = None
 
         loss_layer = torch.nn.CrossEntropyLoss()
         print("Starting training...")
-        best_mrr = 0
         for it in range(self.model.cur_itr.data, self.num_iterations+1):
             last_batch = False
             self.model.train()
@@ -145,28 +210,29 @@ class Experiment:
 
             print("Iteration#: {}, loss: {}".format(it, losses))
 
-            if(it % 100 == 0):
+            # Evaluate the model every 100th iteration or if it is the last iteration
+            if (it % 100 == 0) or (it == self.num_iterations):
                 self.model.eval()
                 with torch.no_grad():
                     print("validation:")
                     tester = Tester(self.dataset, self.model, "valid", self.model_name)
                     measure_valid, _ = tester.test()
                     mrr = measure_valid.mrr["fil"]
-                    if(mrr > best_mrr):
-                        best_mrr = mrr
-                        best_model = self.model
+                    # Save the model at checkpoint
+                    self.save_model(it, "valid", is_best_model=(mrr > self.best_mrr))
+                    if (mrr > self.best_mrr):
+                        self.best_mrr = mrr
+                        self.best_model = self.model
                         self.best_itr = it
-                        # Save the model at checkpoint
-                        self.save_model(it, "valid")
 
 
-        if best_model is None:
-            best_model = self.model
+        if self.best_model is None:
+            self.best_model = self.model
             self.best_itr = it
-        best_model.eval()
+        self.best_model.eval()
         with torch.no_grad():
             print("test in iteration {}:".format(self.best_itr))
-            tester = Tester(self.dataset, best_model, "test", self.model_name)
+            tester = Tester(self.dataset, self.best_model, "test", self.model_name)
             self.measure, self.measure_by_arity = tester.test(self.test_by_arity)
 
         # Save the model at checkpoint
@@ -190,12 +256,17 @@ class Experiment:
         return output_dir
 
 
-    def save_model(self, itr=None, test_or_valid='test'):
+    def save_model(self, itr=None, test_or_valid='test', is_best_model=False):
             """
-            Save the model state to the output folder
+            Save the model state to the output folder.
+            If is_best_model is True, then save the model also as best_model.chkpt
             """
-            model_name = 'model_{}itr.chkpnt'.format(itr) if itr else self.model_name+'.chkpnt'
-            opt_name = 'opt_{}itr.chkpnt'.format(itr) if itr else self.model_name+'.chkpnt'
+            if is_best_model:
+                torch.save(self.model.state_dict(), os.path.join(self.output_dir, 'best_model.chkpt'))
+                #torch.save(self.opt.state_dict(), os.path.join(self.output_dir, 'best_opt.chkpt'))
+
+            model_name = 'model_{}itr.chkpnt'.format(itr) if itr else '{}.chkpnt'.format(self.model_name)
+            opt_name = 'opt_{}itr.chkpnt'.format(itr) if itr else '{}.chkpnt'.format(self.model_name)
             measure_name = '{}_measure_{}itr.json'.format(test_or_valid, itr) if itr else '{}.json'.format(self.model_name)
 
             torch.save(self.model.state_dict(), os.path.join(self.output_dir, model_name))
@@ -234,16 +305,18 @@ if __name__ == '__main__':
     parser.add_argument('-batch_size', type=int, default=128)
     parser.add_argument("-test", action="store_true")
     parser.add_argument("-no_test_by_arity", action="store_true")
-    parser.add_argument('-pretrained', type=str, default=None, help="A path to a trained model, which will be loaded if provided.")
+    parser.add_argument('-pretrained', type=str, default=None, help="A path to a trained model (.chkpnt file), which will be loaded if provided.")
+    parser.add_argument('-output_dir', type=str, default=None, help="A path to the directory where the model will be saved and/or loaded from.")
+    parser.add_argument('-restartable', action="store_true", help="If restartable is set, then you must specify an output_dir")
     args = parser.parse_args()
+
+    if args.restarable and (args.output_dir is None):
+            parser.error("-restarable requires -output_dir.")
 
     # Load the dataset
     dataset = Dataset(args.dataset, DEFAULT_MAX_ARITY)
 
-    experiment = Experiment(args.model, dataset, args.num_iterations, batch_size=args.batch_size, learning_rate=args.lr,
-                            emb_dim=args.emb_dim, max_arity=DEFAULT_MAX_ARITY, hidden_drop=args.hidden_drop,
-                            input_drop=args.input_drop, neg_ratio=args.nr, in_channels=args.in_channels, out_channels=args.out_channels,
-                            filt_h=args.filt_h, filt_w=args.filt_w, stride=args.stride, pretrained=args.pretrained, no_test_by_arity=args.no_test_by_arity)
+    experiment = Experiment(args)
 
     if args.test:
         print("************** START OF TESTING ********************", experiment.model_name)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 import os
+import glob
+import re
 import json
 import datetime
 import numpy as np
@@ -21,27 +23,26 @@ class Experiment:
         self.batch_size = args.batch_size
         self.neg_ratio = args.nr
         self.max_arity = DEFAULT_MAX_ARITY
-        self.dataset = args.dataset
         self.pretrained = args.pretrained
         self.test = args.test
         self.output_dir = args.output_dir
-        self.restartable = args.test
+        self.restartable = args.restartable
         self.device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
         self.kwargs = {"in_channels":args.in_channels,"out_channels":args.out_channels, "filt_h":args.filt_h, "filt_w":args.filt_w,
                        "hidden_drop":args.hidden_drop, "stride":args.stride, "input_drop":args.input_drop}
         self.hyperpars = {"model":args.model,"lr":args.lr,"emb_dim":args.emb_dim,"out_channels":args.out_channels,
-                          "filt_w":filt_w,"nr":args.nr,"stride":args.stride, "hidden_drop":args.hidden_drop, "input_drop":args.input_drop}
+                          "filt_w":args.filt_w,"nr":args.nr,"stride":args.stride, "hidden_drop":args.hidden_drop, "input_drop":args.input_drop}
 
+        # Load the dataset
+        self.dataset = Dataset(args.dataset, DEFAULT_MAX_ARITY)
 
-        self.num_iterations = num_iterations
-        self.stride = stride
+        self.num_iterations = args.num_iterations
         # Create an output dir unless one is given
-        self.output_dir = self.create_output_dir(output_dir)
+        self.output_dir = self.create_output_dir(args.output_dir)
         self.measure = None
         self.measure_by_arity = None
-        self.test_by_arity = not no_test_by_arity
+        self.test_by_arity = not args.no_test_by_arity
         self.best_model = None
-        self.best_mrr = 0
         # Load the specified model and initialize based on given checkpoint (if any)
         self.load_model()
 
@@ -86,7 +87,7 @@ class Experiment:
     def load_last_saved_model(self, output_dir):
         """
         Find the last saved model in the output_dir and load it.
-        Load also the best_model and best_mrr
+        Load also the best_model
         If no model found in the output_dir or if the dir does not exists
         initialize the model randomly.
         Sets self.model, self.best_model
@@ -95,22 +96,22 @@ class Experiment:
         # If the output_dir contains a model, then it will be loaded
         # Pick the latest saved model
         try:
-            # List the checkpoint files in the dir
-            models_list = sorted(glob.glob(os.path.join(self.outut_dir, 'model_*.chkpnt')),
-                key=lambda f: int(re.match(r'model_(\d+)itr.chkpnt', f).groups(0)[0]))
+            # Get the list of checkpoint files and strip the full path
+            model_list = [os.path.basename(x) for x in glob.glob(os.path.join(self.output_dir, 'model_*.chkpnt'))]
+            # Sort the files based on the iteration number
+            model_list_sorted = sorted(model_list, key=lambda f: int(re.match(r'model_(\d+)itr.chkpnt', f).groups(0)[0]))
         except:
             print("*** NO SAVED MODEL FOUND in {}. LOADING FROM SCRATCH. ****".format(self.output_dir))
             # Initilize the model
             self.model.init()
-        else: # if no exceptions, then run the following code
+        else: # if no exceptions, then run the following
             # If there are saved models
-            if len(models_list) > 0:
+            if len(model_list_sorted) > 0:
                 # Pick the most recent model
-                self.pretrained = os.path.join(self.output_dir, models_list[-1])
+                self.pretrained = os.path.join(self.output_dir, model_list_sorted[-1])
                 # Construct the name of the optimizer file based on the pretrained model path
                 opt_path = os.path.join(os.path.dirname(self.pretrained), os.path.basename(self.pretrained).replace('model','opt'))
                 if os.path.exists(opt_path):
-                    print("Loading the model {}".format(self.pretrained))
                     self.model.load_state_dict(torch.load(self.pretrained))
                     self.opt.load_state_dict(torch.load(opt_path))
                     model_found = True
@@ -118,14 +119,13 @@ class Experiment:
                     try:
                         # Load the best model
                         best_model_path = os.path.join(self.output_dir, "best_model.chkpnt")
-                        self.best_model = get_model_from_name(self.model_name)
+                        self.best_model = self.get_model_from_name(self.model_name)
                         self.best_model.load_state_dict(torch.load(best_model_path))
-                        self.best_mrr = self.best_model.best_mrr.data
+                        print("Loading the model {} with best MRR {}.".format(self.pretrained, self.best_model.best_mrr))
                     except:
                         print("*** NO BEST MODEL FOUND in {}. ****".format(self.output_dir))
                         # Set the best model to None
                         self.best_model = None
-                        self.best_mrr = 0
 
         if not model_found:
             print("*** NO MODEL/OPTIMIZER FOUND in {}. LOADING FROM SCRATCH. ****".format(self.output_dir))
@@ -139,24 +139,26 @@ class Experiment:
         """ Priority is given to pretrained model. """
 
         print("Initializing the model ...")
-        self.model = get_model_from_name(self.model_name)
+        self.model = self.get_model_from_name(self.model_name)
 
         # Load the pretrained model
         self.opt = torch.optim.Adagrad(self.model.parameters(), lr=self.learning_rate)
 
-        if self.test and self.pretrained is not None:
+        if self.pretrained is not None:
             print("Loading the pretrained model at {} for testing".format(self.pretrained))
             self.model.load_state_dict(torch.load(self.pretrained))
             # Construct the name of the optimizer file based on the pretrained model path
             opt_path = os.path.join(os.path.dirname(self.pretrained), os.path.basename(self.pretrained).replace('model','opt'))
             # If an optimizer exists (needed for training, but not testing), then load it.
-            #if os.path.exists(opt_path):
-            #    self.opt.load_state_dict(torch.load(opt_path))
-            #else:
-            #    print("*** NO OPTIMIZER FOUND. SKIPPING. ****")
-        elif self.restartable and os.isdir(self.output_dir):
+            if os.path.exists(opt_path):
+                self.opt.load_state_dict(torch.load(opt_path))
+            elif not self.test:
+                # if no optimizer found and 'test` is not set, then raise an error
+                # (we need a pretrained optimizer in order to continue training
+                raise Exception("*** NO OPTIMIZER FOUND. SKIPPING. ****")
+        elif self.restartable and os.path.isdir(self.output_dir):
             # If the output_dir contains a model, then it will be loaded
-            load_last_saved_model(self.output_dir):
+            self.load_last_saved_model(self.output_dir)
         else:
             # Initilize the model
             self.model.init()
@@ -168,6 +170,8 @@ class Experiment:
         with torch.no_grad():
             tester = Tester(self.dataset, self.model, "test", self.model_name)
             self.measure, self.measure_by_arity = tester.test(self.test_by_arity)
+            # Save the result of the tests
+            self.save_model(self.model.cur_itr, "test")
 
 
     def train_and_eval(self):
@@ -184,7 +188,7 @@ class Experiment:
 
 
         loss_layer = torch.nn.CrossEntropyLoss()
-        print("Starting training...")
+        print("Starting training at iteration ... {}".format(self.model.cur_itr.data))
         for it in range(self.model.cur_itr.data, self.num_iterations+1):
             last_batch = False
             self.model.train()
@@ -218,20 +222,24 @@ class Experiment:
                     tester = Tester(self.dataset, self.model, "valid", self.model_name)
                     measure_valid, _ = tester.test()
                     mrr = measure_valid.mrr["fil"]
-                    # Save the model at checkpoint
-                    self.save_model(it, "valid", is_best_model=(mrr > self.best_mrr))
-                    if (mrr > self.best_mrr):
-                        self.best_mrr = mrr
+                    # This is the best model we have so far if
+                    # no "best_model" exists yes, or if this MRR is better than what we had before
+                    is_best_model = (self.best_model is None) or (mrr > self.best_model.best_mrr)
+                    if is_best_model:
                         self.best_model = self.model
-                        self.best_itr = it
+                        # Update the best_mrr value
+                        self.best_model.best_mrr.data = torch.from_numpy(np.array([mrr]))
+                        self.best_model.best_itr.data = torch.from_numpy(np.array([it]))
+                    # Save the model at checkpoint
+                    self.save_model(it, "valid", is_best_model=is_best_model)
 
 
-        if self.best_model is None:
-            self.best_model = self.model
-            self.best_itr = it
+        #if self.best_model is None:
+        #    self.best_model = self.model
+
         self.best_model.eval()
         with torch.no_grad():
-            print("test in iteration {}:".format(self.best_itr))
+            print("testing best model at iteration {} .... ".format(self.best_model.best_itr))
             tester = Tester(self.dataset, self.best_model, "test", self.model_name)
             self.measure, self.measure_by_arity = tester.test(self.test_by_arity)
 
@@ -248,38 +256,41 @@ class Experiment:
             time = datetime.datetime.now()
             model_name = '{}_{}_{}'.format(self.model_name, self.dataset.name, time.strftime("%Y%m%d-%H%M%S"))
             output_dir = os.path.join(DEFAULT_SAVE_DIR, self.model_name, model_name)
-        else:
-            output_dir = os.path.dirname(self.pretrained)
 
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
+            print("Created output directory {}".format(output_dir))
         return output_dir
 
 
-    def save_model(self, itr=None, test_or_valid='test', is_best_model=False):
+    def save_model(self, itr=0, test_or_valid='test', is_best_model=False):
             """
             Save the model state to the output folder.
-            If is_best_model is True, then save the model also as best_model.chkpt
+            If is_best_model is True, then save the model also as best_model.chkpnt
             """
             if is_best_model:
-                torch.save(self.model.state_dict(), os.path.join(self.output_dir, 'best_model.chkpt'))
-                #torch.save(self.opt.state_dict(), os.path.join(self.output_dir, 'best_opt.chkpt'))
+                torch.save(self.model.state_dict(), os.path.join(self.output_dir, 'best_model.chkpnt'))
+                print("######## Saving the BEST MODEL")
 
-            model_name = 'model_{}itr.chkpnt'.format(itr) if itr else '{}.chkpnt'.format(self.model_name)
+            model_name = 'model_{}itr.chkpnt'.format(itr)
+            #model_name = 'model_{}itr.chkpnt'.format(itr) if itr else '{}.chkpnt'.format(self.model_name)
             opt_name = 'opt_{}itr.chkpnt'.format(itr) if itr else '{}.chkpnt'.format(self.model_name)
             measure_name = '{}_measure_{}itr.json'.format(test_or_valid, itr) if itr else '{}.json'.format(self.model_name)
+            print("######## Saving the model {}".format(os.path.join(self.output_dir, model_name)))
 
             torch.save(self.model.state_dict(), os.path.join(self.output_dir, model_name))
             torch.save(self.opt.state_dict(), os.path.join(self.output_dir, opt_name))
             if self.measure is not None:
                 measure_dict = vars(self.measure)
-                measure_dict["best_iteration"] = self.best_itr
+                # If a best model exists
+                if self.best_model:
+                    measure_dict["best_iteration"] = self.best_model.best_itr.cpu().item()
+                    measure_dict["best_mrr"] = self.best_model.best_mrr.cpu().item()
                 with open(os.path.join(self.output_dir, measure_name), 'w') as f:
                         json.dump(measure_dict, f, indent=4, sort_keys=True)
             # Note that measure_by_arity is only computed at test time (not validation)
             if (self.test_by_arity) and (self.measure_by_arity is not None):
                 H = {}
-                H["best_iteration"] = self.best_itr
                 measure_by_arity_name = '{}_measure_{}itr_by_arity.json'.format(test_or_valid, itr) if itr else '{}.json'.format(self.model_name)
                 for key in self.measure_by_arity:
                     H[key] = vars(self.measure_by_arity[key])
@@ -310,11 +321,8 @@ if __name__ == '__main__':
     parser.add_argument('-restartable', action="store_true", help="If restartable is set, then you must specify an output_dir")
     args = parser.parse_args()
 
-    if args.restarable and (args.output_dir is None):
+    if args.restartable and (args.output_dir is None):
             parser.error("-restarable requires -output_dir.")
-
-    # Load the dataset
-    dataset = Dataset(args.dataset, DEFAULT_MAX_ARITY)
 
     experiment = Experiment(args)
 

--- a/main.py
+++ b/main.py
@@ -314,11 +314,12 @@ if __name__ == '__main__':
     parser.add_argument('-stride', type=int, default=2)
     parser.add_argument('-num_iterations', type=int, default=1000)
     parser.add_argument('-batch_size', type=int, default=128)
-    parser.add_argument("-test", action="store_true")
-    parser.add_argument("-no_test_by_arity", action="store_true")
+    parser.add_argument("-test", action="store_true", help="If -test is set, then you must specify a -pretrained model. "
+                        + "This will perform testing on the pretrained model and save the output in -output_dir")
+    parser.add_argument("-no_test_by_arity", action="store_true", help="If set, then validation will be performed by arity.")
     parser.add_argument('-pretrained', type=str, default=None, help="A path to a trained model (.chkpnt file), which will be loaded if provided.")
     parser.add_argument('-output_dir', type=str, default=None, help="A path to the directory where the model will be saved and/or loaded from.")
-    parser.add_argument('-restartable', action="store_true", help="If restartable is set, then you must specify an output_dir")
+    parser.add_argument('-restartable', action="store_true", help="If restartable is set, you must specify an output_dir")
     args = parser.parse_args()
 
     if args.restartable and (args.output_dir is None):

--- a/models.py
+++ b/models.py
@@ -15,6 +15,7 @@ import math
 class BaseClass(torch.nn.Module):
     def __init__(self):
         super(BaseClass, self).__init__()
+        self.best_mrr = torch.nn.Parameter(torch.tensor(0, dtype=torch.float64), requires_grad=False)
         self.cur_itr = torch.nn.Parameter(torch.tensor(0, dtype=torch.int32), requires_grad=False)
 
 

--- a/models.py
+++ b/models.py
@@ -15,8 +15,9 @@ import math
 class BaseClass(torch.nn.Module):
     def __init__(self):
         super(BaseClass, self).__init__()
-        self.best_mrr = torch.nn.Parameter(torch.tensor(0, dtype=torch.float64), requires_grad=False)
         self.cur_itr = torch.nn.Parameter(torch.tensor(0, dtype=torch.int32), requires_grad=False)
+        self.best_mrr = torch.nn.Parameter(torch.tensor(0, dtype=torch.float64), requires_grad=False)
+        self.best_itr = torch.nn.Parameter(torch.tensor(0, dtype=torch.int32), requires_grad=False)
 
 
 class MDistMult(BaseClass):


### PR DESCRIPTION
Adds the functionality of restarting a job where it was interrupted.

Added the command argument `-restartable`, which when set will resume the job where it was left off. To use this option, you must specify an output directory with `-output_dir`.

